### PR TITLE
Disable concurrent builds to avoid pipeline jobs from running wild

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ spec:
   options {
     buildDiscarder(logRotator(numToKeepStr: '5'))
     checkoutToSubdirectory('hugo')
+    disableConcurrentBuilds()
   }
 
   triggers {


### PR DESCRIPTION
Signed-off-by: Frederic Gurr <frederic.gurr@eclipse-foundation.org>